### PR TITLE
Expand ResponseError with response object

### DIFF
--- a/GirdersSwift/src/main/swift/http/Errors.swift
+++ b/GirdersSwift/src/main/swift/http/Errors.swift
@@ -5,39 +5,39 @@ import Foundation
 // code is needed.
 //
 // In case error message from the server needs to be supported, use enum with associated values.
-public enum ResponseError: Error {
-    case BadRequest
-    case Unauthorized
-    case Forbidden
-    case NotFound
-    case MethodNotAllowed
-    case InternalServerError
-    case NotImplemented
-    case BadGateway
-    case Unknown
+public enum ResponseError<T>: Error {
+    case BadRequest(response: Response<T>)
+    case Unauthorized(response: Response<T>)
+    case Forbidden(response: Response<T>)
+    case NotFound(response: Response<T>)
+    case MethodNotAllowed(response: Response<T>)
+    case InternalServerError(response: Response<T>)
+    case NotImplemented(response: Response<T>)
+    case BadGateway(response: Response<T>)
+    case Unknown(response: Response<T>)
 }
 
 extension ResponseError {
-    public static func error(fromResponse response: HTTPURLResponse) -> ResponseError {
+    public static func error(fromResponse response: Response<T>) -> ResponseError {
         switch response.statusCode {
         case 400:
-            return .BadRequest
+            return .BadRequest(response: response)
         case 401:
-            return .Unauthorized
+            return .Unauthorized(response: response)
         case 403:
-            return .Forbidden
+            return .Forbidden(response: response)
         case 404:
-            return .NotFound
+            return .NotFound(response: response)
         case 405:
-            return .MethodNotAllowed
+            return .MethodNotAllowed(response: response)
         case 500:
-            return .InternalServerError
+            return .InternalServerError(response: response)
         case 501:
-            return .NotImplemented
+            return .NotImplemented(response: response)
         case 502:
-            return .BadGateway
+            return .BadGateway(response: response)
         default:
-            return .Unknown
+            return .Unknown(response: response)
         }
     }
 }

--- a/GirdersSwift/src/main/swift/http/HTTPClient.swift
+++ b/GirdersSwift/src/main/swift/http/HTTPClient.swift
@@ -99,16 +99,16 @@ extension HTTPClient: HTTP {
         -> Result<Response<T>, Error?> {
         var result: Result<Response<T>, Error?> = Result.Failure(nil)
         if let httpResponse = urlResponse as? HTTPURLResponse {
+            let bodyObject: T? = self.parseBody(data: data as Data?)
+            let response: Response<T> = Response(statusCode: httpResponse.statusCode,
+                                                 body: data as Data?,
+                                                 bodyObject: bodyObject,
+                                                 responseHeaders: httpResponse.allHeaderFields,
+                                                 url: httpResponse.url)
             if (httpResponse.statusCode / 100) == 2 {
-                let bodyObject: T? = self.parseBody(data: data as Data?)
-                let response: Response<T> = Response(statusCode: httpResponse.statusCode,
-                                                     body: data as Data?,
-                                                     bodyObject: bodyObject,
-                                                     responseHeaders: httpResponse.allHeaderFields,
-                                                     url: httpResponse.url)
                 result = Result.Success(response)
             } else {
-                let responseError = ResponseError.error(fromResponse: httpResponse)
+                let responseError = ResponseError<T>.error(fromResponse: response)
                 result = Result.Failure(responseError)
             }
         } else {


### PR DESCRIPTION
Like discussed with Martin, I expanded the Errorhandling of the HTTP Client, so we can also receive response data when a request fails.