### PR TITLE
FIX Memory leak issue in HTTPClient

### DIFF
--- a/GirdersSwift/src/main/swift/http/HTTPClient.swift
+++ b/GirdersSwift/src/main/swift/http/HTTPClient.swift
@@ -32,6 +32,10 @@ public class HTTPClient {
         sessionDelegate.httpClient = self
     }
     
+    deinit {
+        self.urlSession.finishTasksAndInvalidate()
+    }
+    
     /// Extracts the credentials for a given url request.
     ///
     /// - Parameter request: The given url request.


### PR DESCRIPTION
Like discussed, the urlSession from apple is a singleton and we have to call finishTasksAndInvalidate on our urlSession to avoid leaks .