### PR TITLE
Public initializer for Response object

### DIFF
--- a/GirdersSwift/src/main/swift/http/HTTP.swift
+++ b/GirdersSwift/src/main/swift/http/HTTP.swift
@@ -28,6 +28,19 @@ public struct Response<T> {
     
     // The url of the response.
     public let url: URL?
+
+    public init(statusCode: Int,
+                body: Data?,
+                bodyObject: T?,
+                responseHeaders: [AnyHashable : Any],
+                url: URL?) {
+        self.statusCode = statusCode
+        self.body = body
+        self.bodyObject = bodyObject
+        self.responseHeaders = responseHeaders
+        self.url = url
+    }
+    
 }
 
 /// The protocol that declares methods for http communication. 


### PR DESCRIPTION
As structs provide default initializer only for internal visibility.