### PR TITLE
Improvement in HTTPPromise

### DIFF
--- a/GirdersSwift/src/main/swift/promise/HTTPPromise.swift
+++ b/GirdersSwift/src/main/swift/promise/HTTPPromise.swift
@@ -1,6 +1,8 @@
 import Foundation
 import PromiseKit
 
+
+
 /// Extension of the standard HTTP with Promises.
 public extension HTTP {
     
@@ -8,14 +10,24 @@ public extension HTTP {
         return Promise { seal in
             executeRequest(request: request,
                            completionHandler: { (result: Result<Response<T>, Error?>) in
-                switch result {
-                case .Failure(let error):
-                    seal.reject(error!)
-                case .Success(let data):
-                    seal.fulfill(data)
-                }
+                            switch result {
+                            case .Failure(let error):
+                                if error!.isCancelled {
+                                    seal.reject(self.canceledErrorForRequest(request))
+                                } else {
+                                    seal.reject(error!)
+                                }
+                            case .Success(let data):
+                                seal.fulfill(data)
+                            }
             })
         }
+    }
+    
+    func canceledErrorForRequest(_ request: Request) -> Error {
+        return NSError(domain: "com.netcetera.GirdersSwift",
+                code: 01,
+                userInfo: ["The request was canceled" : request])
     }
     
 }


### PR DESCRIPTION
If the error is canceled, and the promise is sealed with a canceled error, the catch block of the promise is not called. So when a canceled error is received the promise is sealed with a custom canceled request error