### PR TITLE
ADD Support for url query parameters with same name

### DIFF
--- a/GirdersSwift.podspec
+++ b/GirdersSwift.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'GirdersSwift'
-  s.version = '0.7.0'
+  s.version = '0.7.1'
   s.summary  = 'Girders for iOS, written in Swift.'
   s.homepage = 'https://www.netcetera.com'
   s.author   = 'Netcetera'
   s.description = 'A library that reduces development time for iOS Swift applications.'
   s.platform = :ios, '11.0'
-  s.source = { :git => 'https://github.com/netceteragroup/GirdersSwift.git', :tag => '0.7.0' }
+  s.source = { :git => 'https://github.com/netceteragroup/GirdersSwift.git', :tag => '0.7.1' }
   s.requires_arc = true
   s.swift_version = "5.0"
   s.module_name = 'GirdersSwift'

--- a/Sources/GirdersSwift/http/Request.swift
+++ b/Sources/GirdersSwift/http/Request.swift
@@ -154,6 +154,15 @@ public struct MutableRequest : RequestGenerator {
             self.queryString =
                 params.urlEncodedQueryStringWithEncoding(encoding: String.Encoding.utf8)
         }
+        if let params = parameters as? [URLQueryItem] {
+            var urlComponents = URLComponents()
+            let encodedQueryParams = params.map {
+                URLQueryItem(name: $0.name.urlEncodedStringWithEncoding(),
+                             value: $0.value?.urlEncodedStringWithEncoding())
+            }
+            urlComponents.queryItems = encodedQueryParams
+            self.queryString = urlComponents.query!
+        }
     }
     
     public mutating func updateSSLCredentials(sslCredentials: SSLCredentials) {

--- a/Sources/GirdersSwift/http/Request.swift
+++ b/Sources/GirdersSwift/http/Request.swift
@@ -150,11 +150,10 @@ public struct MutableRequest : RequestGenerator {
     }
     
     public mutating func updateQueryParameters(parameters: Any?) {
-        if let params = parameters as? [String: AnyObject] {
-            self.queryString =
-                params.urlEncodedQueryStringWithEncoding(encoding: String.Encoding.utf8)
-        }
-        if let params = parameters as? [URLQueryItem] {
+        switch parameters {
+        case let params as [String: AnyObject]:
+            self.queryString = params.urlEncodedQueryStringWithEncoding(encoding: String.Encoding.utf8)
+        case let params as [URLQueryItem]:
             var urlComponents = URLComponents()
             let encodedQueryParams = params.map {
                 URLQueryItem(name: $0.name.urlEncodedStringWithEncoding(),
@@ -162,6 +161,8 @@ public struct MutableRequest : RequestGenerator {
             }
             urlComponents.queryItems = encodedQueryParams
             self.queryString = urlComponents.query!
+        default:
+            self.queryString = nil
         }
     }
     

--- a/Sources/GirdersSwift/http/Request.swift
+++ b/Sources/GirdersSwift/http/Request.swift
@@ -154,16 +154,20 @@ public struct MutableRequest : RequestGenerator {
         case let params as [String: AnyObject]:
             self.queryString = params.urlEncodedQueryStringWithEncoding(encoding: String.Encoding.utf8)
         case let params as [URLQueryItem]:
-            var urlComponents = URLComponents()
-            let encodedQueryParams = params.map {
-                URLQueryItem(name: $0.name.urlEncodedStringWithEncoding(),
-                             value: $0.value?.urlEncodedStringWithEncoding())
-            }
-            urlComponents.queryItems = encodedQueryParams
-            self.queryString = urlComponents.query!
+            updateQueryParameters(params: params)
         default:
             self.queryString = nil
         }
+    }
+    
+    private mutating func updateQueryParameters(params: [URLQueryItem]) {
+        var urlComponents = URLComponents()
+        let encodedQueryParams = params.map {
+            URLQueryItem(name: $0.name.urlEncodedStringWithEncoding(),
+                         value: $0.value?.urlEncodedStringWithEncoding())
+        }
+        urlComponents.queryItems = encodedQueryParams
+        self.queryString = urlComponents.query!
     }
     
     public mutating func updateSSLCredentials(sslCredentials: SSLCredentials) {

--- a/Tests/GirdersSwiftTests/swift/http/TestRequestGenerator.swift
+++ b/Tests/GirdersSwiftTests/swift/http/TestRequestGenerator.swift
@@ -108,13 +108,37 @@ class TestMutableRequest: XCTestCase {
         XCTAssertNotNil(request.parameters)
     }
 
-    func testUpdateQueryParameters() {
+    func mutableRequestWithQuery(_ params: Any) -> MutableRequest {
         var request = mockGenerator.generateRequest(withMethod: .GET)
-        let queryParameters = [URLQueryItem(name: "token", value: "token1")]
+        request.updateQueryParameters(parameters: params)
+        return request
+    }
+    
+    func testQueryParametersAreProperlySetWhenURLQueryItemConfigurationIsUsed() {
+        let queryParameters = [URLQueryItem(name: "token1", value: "token1"),
+                               URLQueryItem(name: "token2", value: "token2")]
+        let request = mutableRequestWithQuery(queryParameters)
+        XCTAssertTrue(request.queryString!.contains("token1=token1"))
+        XCTAssertTrue(request.queryString!.contains("token2=token2"))
+    }
+    
+    func testQueryParametersAreSetWhenEqualKeysAreBeingUsed() {
+        let queryParameters = [URLQueryItem(name: "token1", value: "token1"),
+                               URLQueryItem(name: "token1", value: "token2")]
 
-        request.updateQueryParameters(parameters: queryParameters)
+        let request = mutableRequestWithQuery(queryParameters)
+        XCTAssertTrue(request.queryString!.contains("token1=token1"))
+        XCTAssertTrue(request.queryString!.contains("token1=token2"))
+    }
+    
+    func testURLEscapeEncodingIsAppliedInQueryString() {
+        let param1 = "New Parameter"
+        let value1 = "Hello, world!"
         
-        XCTAssertNotNil(request.queryString)
+        let queryParameters = [URLQueryItem(name: param1, value: value1)]
+        let request = mutableRequestWithQuery(queryParameters)
+        XCTAssertEqual(request.queryString!,
+                       ("\(param1.urlEncodedStringWithEncoding())=\(value1.urlEncodedStringWithEncoding())"))
     }
     
     func testUpdateQueryParametersFromUnsupportedType() {

--- a/Tests/GirdersSwiftTests/swift/http/TestRequestGenerator.swift
+++ b/Tests/GirdersSwiftTests/swift/http/TestRequestGenerator.swift
@@ -107,6 +107,24 @@ class TestMutableRequest: XCTestCase {
         
         XCTAssertNotNil(request.parameters)
     }
+
+    func testUpdateQueryParameters() {
+        var request = mockGenerator.generateRequest(withMethod: .GET)
+        let queryParameters = [URLQueryItem(name: "token", value: "token1")]
+
+        request.updateQueryParameters(parameters: queryParameters)
+        
+        XCTAssertNotNil(request.queryString)
+    }
+    
+    func testUpdateQueryParametersFromUnsupportedType() {
+        var request = mockGenerator.generateRequest(withMethod: .GET)
+        let queryParameters = ["param1=value1", "param2=value2"]
+
+        request.updateQueryParameters(parameters: queryParameters)
+
+        XCTAssertNil(request.queryString)
+    }
     
     func testupdateHTTPHeaderFields() {
         var request = mockGenerator.request(withMethod: .POST) |> mockGenerator.withBasicAuth |> mockGenerator.withJsonSupport

--- a/Tests/GirdersSwiftTests/swift/http/TestRequestGenerator.swift
+++ b/Tests/GirdersSwiftTests/swift/http/TestRequestGenerator.swift
@@ -107,12 +107,6 @@ class TestMutableRequest: XCTestCase {
         
         XCTAssertNotNil(request.parameters)
     }
-
-    func mutableRequestWithQuery(_ params: Any) -> MutableRequest {
-        var request = mockGenerator.generateRequest(withMethod: .GET)
-        request.updateQueryParameters(parameters: params)
-        return request
-    }
     
     func testQueryParametersAreProperlySetWhenURLQueryItemConfigurationIsUsed() {
         let queryParameters = [URLQueryItem(name: "token1", value: "token1"),
@@ -150,7 +144,7 @@ class TestMutableRequest: XCTestCase {
         XCTAssertNil(request.queryString)
     }
     
-    func testupdateHTTPHeaderFields() {
+    func testUpdateHTTPHeaderFields() {
         var request = mockGenerator.request(withMethod: .POST) |> mockGenerator.withBasicAuth |> mockGenerator.withJsonSupport
         
         XCTAssertEqual(request.headerFields["Accept"], "application/json")
@@ -162,4 +156,13 @@ class TestMutableRequest: XCTestCase {
         
         XCTAssertNotNil(request.headerFields["Test1"])
     }
+    
+    //  MARK: - Private
+    
+    private func mutableRequestWithQuery(_ params: Any) -> MutableRequest {
+        var request = mockGenerator.generateRequest(withMethod: .GET)
+        request.updateQueryParameters(parameters: params)
+        return request
+    }
+    
 }


### PR DESCRIPTION
When generating HTTP request there was an issue if we generate a GET request with query parameters with a same name. The library only processes dictionary for the url parameter names and values, now it accepts also passing an array of [URLQueryItem] which will support this type of requests:

Example: GET: http://www.netcetera.com/authorise?sameName=dummyValue1&sameName=dummyValue2